### PR TITLE
Nodeguard Worker: Don't mount the Docker socket

### DIFF
--- a/helm-charts/octarine/charts/nodeguard/templates/worker-daemonset.yaml
+++ b/helm-charts/octarine/charts/nodeguard/templates/worker-daemonset.yaml
@@ -33,10 +33,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      volumes:
-        - name: host-docker-sock
-          hostPath:
-            path: /var/run/docker.sock
       priorityClassName: {{ include "octarine.priorityClass.name" . }}
       containers:
         - name: {{ include "nodeguard.worker.name" . }}
@@ -59,9 +55,6 @@ spec:
               command:
                 - cat
                 - {{ .Values.worker.probes.livenessPath }}
-          volumeMounts:
-            - name: host-docker-sock
-              mountPath: /var/run/docker.sock
           command:
             - "/run_worker.sh"
           args:


### PR DESCRIPTION
Don't mount the Docker Unix domain socket in Nodeguard Worker pods, because it's no longer needed.
Nodeguard Worker no longer makes any calls into Docker.