### PR TITLE
Infra129 - create pipeline to push operator images to cbartifactory

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -21,9 +21,7 @@ jobs:
       - name: Setup Operator SDK
         working-directory: ./dependencies
         run: | 
-          git clone -b v0.18.0 https://github.com/operator-framework/operator-sdk ./operator-sdk
-          cd operator-sdk
-          make install
+          git clone -b v0.18.0 https://github.com/operator-framework/operator-sdk
       - name: Build octarine operator
         run: operator-sdk build cbartifactory/octarine-operator:<version>
       - name: Set up Docker Buildx

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -19,9 +19,10 @@ jobs:
         with:
           go-version: 1.15
       - name: Setup Operator SDK
-        working-directory: ./dependencies
         run: | 
           git clone -b v0.18.0 https://github.com/operator-framework/operator-sdk
+          cd operator-sdk
+          make install
       - name: Build octarine operator
         run: operator-sdk build cbartifactory/octarine-operator:<version>
       - name: Set up Docker Buildx

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -33,4 +33,4 @@ jobs:
         with:
           file: ./build/Dockerfile
           push: true
-          tags: cbartifactory/octarine-operator:latest
+          tags: cbartifactory/octarine-operator:${GITHUB_REF##*/}

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -2,8 +2,8 @@ name: Build and publish services
 
 on:
   push:
-    branches:
-      - "*"
+    tags:
+      - "v*.*.*"
   pull_request:
     branches:
       - "*"
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build octarine operator
-        run: operator-sdk build cbartifactory/octarine-operator:infra129
+        run: operator-sdk build cbartifactory/octarine-operator:${{ steps.docker-tag.outputs.tag }}
       - name: Push operator image to CBArtifactory
         id: docker_push
-        run: docker push cbartifactory/octarine-operator:infra129  #${{ steps.docker-tag.outputs.tag }}
+        run: docker push cbartifactory/octarine-operator:${{ steps.docker-tag.outputs.tag }} 

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Operator SDK
         working-directory: ./dependencies
         run: | 
-          git clone -b v0.18.0 https://github.com/operator-framework/operator-sdk
+          git clone -b v0.18.0 https://github.com/operator-framework/operator-sdk ./operator-sdk
           cd operator-sdk
           make install
       - name: Build octarine operator

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -23,21 +23,17 @@ jobs:
           git clone -b v0.18.0 https://github.com/operator-framework/operator-sdk
           cd operator-sdk
           make install
-      - name: Build octarine operator
-        run: operator-sdk build cbartifactory/octarine-operator:infra129
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      # - id: docker-tag
-      #   uses: yuya-takeyama/docker-tag-from-github-ref-action@v1
-      # - name: Build and push
-      #   id: docker_build
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     file: ./build/Dockerfile
-      #     push: true
-      #     tags: cbartifactory/octarine-operator:${{ steps.docker-tag.outputs.tag }}
+      - id: docker-tag
+        uses: yuya-takeyama/docker-tag-from-github-ref-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build octarine operator
+        run: operator-sdk build cbartifactory/octarine-operator:infra129
+      - name: Push operator image to CBArtifactory
+        id: docker_push
+        run: docker push cbartifactory/octarine-operator:infra129  #${{ steps.docker-tag.outputs.tag }}

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -20,15 +20,13 @@ jobs:
           go-version: 1.15
       - name: Build
         run: go build -v ./...
-      - name: Test
-        run: go test -v ./...
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.secrets.dockerhub_user }}
-          password: ${{ secrets.dockerhub_password }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -27,6 +27,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - id: docker-tag
+        uses: yuya-takeyama/docker-tag-from-github-ref-action@v1
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -25,3 +25,12 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.secrets.dockerhub_user }}
+          password: ${{ secrets.dockerhub_password }}
+          repository: cbartifactory/octarine-operator
+          file: ./build/Dockerfile
+          tag_with_ref: true

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -24,7 +24,7 @@ jobs:
           cd operator-sdk
           make install
       - name: Build octarine operator
-        run: operator-sdk build cbartifactory/octarine-operator:<version>
+        run: operator-sdk build cbartifactory/octarine-operator:infra129
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -31,6 +31,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          dockerfile: ./build/Dockerfile
+          file: ./build/Dockerfile
           push: true
           tags: cbartifactory/octarine-operator:latest

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -33,4 +33,4 @@ jobs:
         with:
           file: ./build/Dockerfile
           push: true
-          tags: cbartifactory/octarine-operator:${GITHUB_REF##*/}
+          tags: cbartifactory/octarine-operator:${{ steps.docker-tag.outputs.tag }}

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -1,0 +1,27 @@
+name: Build and publish services
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+      -
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -14,23 +14,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
-
       - name: Build
         run: go build -v ./...
-
       - name: Test
         run: go test -v ./...
 
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.secrets.dockerhub_user }}
           password: ${{ secrets.dockerhub_password }}
-          repository: cbartifactory/octarine-operator
-          file: ./build/Dockerfile
-          tag_with_ref: true
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          dockerfile: ./build/Dockerfile
+          push: true
+          tags: cbartifactory/octarine-operator:latest

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -18,8 +18,14 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
-      - name: Build
-        run: go build -v ./...
+      - name: Setup Operator SDK
+        working-directory: ./dependencies
+        run: | 
+          git clone -b v0.18.0 https://github.com/operator-framework/operator-sdk
+          cd operator-sdk
+          make install
+      - name: Build octarine operator
+        run: operator-sdk build cbartifactory/octarine-operator:<version>
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -27,12 +33,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - id: docker-tag
-        uses: yuya-takeyama/docker-tag-from-github-ref-action@v1
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          file: ./build/Dockerfile
-          push: true
-          tags: cbartifactory/octarine-operator:${{ steps.docker-tag.outputs.tag }}
+      # - id: docker-tag
+      #   uses: yuya-takeyama/docker-tag-from-github-ref-action@v1
+      # - name: Build and push
+      #   id: docker_build
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     file: ./build/Dockerfile
+      #     push: true
+      #     tags: cbartifactory/octarine-operator:${{ steps.docker-tag.outputs.tag }}

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -22,10 +22,6 @@ jobs:
         run: go build -v ./...
       - name: Test
         run: go test -v ./...
-
-  docker:
-    runs-on: ubuntu-latest
-    steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub


### PR DESCRIPTION
Creates a github workflow that will push operator images to Cbartifactory with the proper credentials. 
The workflow only runs on tags in the form "v*.*.*" - all other tags can use non-cbartifactory repos for testing. 

Solves Infra-129