### PR TITLE
Expose metrics with in a secured way (using rbac proxy container)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ rules:
 
 Cluster Role binding creation:
 ```sh
-kubectl create clusterrolebinding metrics --clusterrole=cbcontainers-metrics-reader --serviceaccount=<namespace>:<service-account-name>
+kubectl create clusterrolebinding metrics --clusterrole=cbcontainers-metrics-reader --serviceaccount=<prometheus-namespace>:<prometheus-service-account-name>
 ```
 
 ### When using Prometheus Operator

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ make undeploy
 
 The operator metrics are protected by kube-auth-proxy.
 
-You will need to grant permissions to your Prometheus server so that it can scrape the protected metrics.
+You will need to grant permissions to your Prometheus server to allow it to scrape the protected metrics.
 
 You can create a ClusterRole and bind it with ClusterRoleBinding to the service account that your Prometheus server uses.
-If you don't have such cluster role & cluster role binding configured:
+
+If you don't have such cluster role & cluster role binding configured, you can use the following:
 
 Cluster Role:
 ```sh
@@ -121,8 +122,8 @@ kubectl create clusterrolebinding metrics --clusterrole=cbcontainers-metrics-rea
 
 ### When using Prometheus Operator
 
-The Service Monitor to add for scraping metrics from the CBContainers operator:
-* Make sure that your Prometheus custom resource service monitor selectors can match it. 
+Use the following ServiceMonitor to start scraping metrics from the CBContainers operator:
+* Make sure that your Prometheus custom resource service monitor selectors match it. 
 ```
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ make undeploy
 ```
 * Notice that the above command will delete the Carbon Black Container custom resources definitions and instances.
 
+## Reading Metrics
+The operator metrics are protected by kube-auth-proxy.
+
+You will need to grant permissions to your Prometheus server so that it can scrape the protected metrics.
+
+To achieve that, you can create a clusterRoleBinding to bind the clusterRole to the service account that your Prometheus server uses.
+If you are using kube-prometheus, this cluster binding already exists.
+
+You can run the following kubectl command to create it:
+```sh
+kubectl create clusterrolebinding metrics --clusterrole=cbcontainers-metrics-reader --serviceaccount=<namespace>:<service-account-name>
+```
+
 ## Using HTTP proxy
 
 Configuring the Carbon Black Cloud Container services to use HTTP proxy can be done by setting HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,6 +9,16 @@ spec:
   template:
     spec:
       containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-#- auth_proxy_service.yaml
-#- auth_proxy_role.yaml
-#- auth_proxy_role_binding.yaml
-#- auth_proxy_client_clusterrole.yaml
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+# - auth_proxy_client_clusterrole.yaml


### PR DESCRIPTION
https://book.kubebuilder.io/reference/metrics.html
https://github.com/brancz/kube-rbac-proxy