### PR TITLE
resolver: Perms for endpoints and endpointslices

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  - ""
+  resources:
+  - services
+  - endpoints
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operator.containers.carbonblack.io
   resources:
   - cbcontainersclusters


### PR DESCRIPTION
Add necessary permissions for the resolver to work with (watch, list, and query) endpoints and endpoint slices.