### PR TITLE
Add a workflow that can be triggered manually

### DIFF
--- a/.github/workflows/manual_push.yaml
+++ b/.github/workflows/manual_push.yaml
@@ -1,0 +1,35 @@
+name: Build and publish services
+
+on:
+  workflow_dispatch:
+    inputs:
+      dockerTag:
+        description: 'Tag to use for the container image'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Setup Operator SDK
+        run: |
+          git clone -b v1.5.0 https://github.com/operator-framework/operator-sdk
+          cd operator-sdk
+          make install
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - run: make generate
+      - run: make manifests
+      - run: make test
+      - name: Build and push
+        run: make docker-build docker-push IMG=cbartifactory/octarine-operator:${{ github.event.inputs.dockerTag }}


### PR DESCRIPTION
This enables testing or working with non-release versions that don't have a semantic version tag (or never should have one). 