### PR TITLE
Allow the node-agent to load on TMC created clusters and TKG

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 # - auth_proxy_client_clusterrole.yaml
+- pod_security_policy.yaml

--- a/config/rbac/pod_security_policy.yaml
+++ b/config/rbac/pod_security_policy.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: manager-psp
+spec:
+  privileged: true
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  allowedCapabilities:
+  - NET_BIND_SERVICE
+  - SYS_ADMIN
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -114,3 +114,11 @@ rules:
   - priorityclasses
   verbs:
   - '*'
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - manager-psp


### PR DESCRIPTION
We require a specific PodSecurityPolicy to be applied for the node agent to run on TMC created Kubernetes clusters. Otherwise we get various cryptic errors (if we get any), ranging from node agent pods not being created or eBPF load errors and crash loop of the node agent pods.