### PR TITLE
Allow for semantic versions to start with "v"

### DIFF
--- a/cbcontainers/state/operator/version_provider.go
+++ b/cbcontainers/state/operator/version_provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 )
 
 var (
@@ -12,7 +13,11 @@ var (
 	// semVerRegexExpr is a regex expression that checks if a string is a regular semantic version.
 	//
 	// source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-	semVerRegexExpr = `^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
+	//
+	// NOTE: we have added an additional optional leading "v" to the official sem ver regex.
+	// This is to account for branch names and tags like "v4.0.0", which is not a valid sem ver,
+	// but we still want to support and treat as "4.0.0".
+	semVerRegexExpr = `^(v?)(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
 	// semVerRegex is the compiled regex that checks if a string is a regular semantic version.
 	semVerRegex = regexp.MustCompile(semVerRegexExpr)
 
@@ -37,5 +42,11 @@ func (p *EnvVersionProvider) GetOperatorVersion() (string, error) {
 	if match := semVerRegex.Match([]byte(v)); !match {
 		return "", fmt.Errorf("%w: %v", ErrNotSemVer, v)
 	}
+	// strip the leading "v" if there is such
+	// that is because strings like "v4.0.0"
+	// are not valid semantic versions, but we still use such strings
+	// for tags and branch names,
+	// so we want ot treat "v4.0.0" as "4.0.0"
+	v = strings.TrimPrefix(v, "v")
 	return v, nil
 }

--- a/cbcontainers/state/operator/version_provider_test.go
+++ b/cbcontainers/state/operator/version_provider_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,38 @@ func TestGetOperatorVersionSemVer(t *testing.T) {
 		"1.2.3----RC-SNAPSHOT.12.9.1--.12":     true,
 		"1.0.0+0.build.1-rc.10000aaa-kk-0.1":   true,
 		"99999999999999999999999.999999999999999999.99999999999999999": true,
-		"1.0.0-0A.is.legal": true,
+		"1.0.0-0A.is.legal":      true,
+		"v0.0.4":                 true,
+		"v1.2.3":                 true,
+		"v10.20.30":              true,
+		"v1.1.2-prerelease+meta": true,
+		"v1.1.2+meta":            true,
+		"v1.1.2+meta-valid":      true,
+		"v1.0.0-alpha":           true,
+		"v1.0.0-beta":            true,
+		"v1.0.0-alpha.beta":      true,
+		"v1.0.0-alpha.beta.1":    true,
+		"v1.0.0-alpha.1":         true,
+		"v1.0.0-alpha0.valid":    true,
+		"v1.0.0-alpha.0valid":    true,
+		"v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay": true,
+		"v1.0.0-rc.1+build.1":                   true,
+		"v2.0.0-rc.1+build.123":                 true,
+		"v1.2.3-beta":                           true,
+		"v10.2.3-DEV-SNAPSHOT":                  true,
+		"v1.2.3-SNAPSHOT-123":                   true,
+		"v1.0.0":                                true,
+		"v2.0.0":                                true,
+		"v1.1.7":                                true,
+		"v2.0.0+build.1848":                     true,
+		"v2.0.1-alpha.1227":                     true,
+		"v1.0.0-alpha+beta":                     true,
+		"v1.2.3----RC-SNAPSHOT.12.9.1--.12+788": true,
+		"v1.2.3----R-S.12.9.1--.12+meta":        true,
+		"v1.2.3----RC-SNAPSHOT.12.9.1--.12":     true,
+		"v1.0.0+0.build.1-rc.10000aaa-kk-0.1":   true,
+		"v99999999999999999999999.999999999999999999.99999999999999999": true,
+		"v1.0.0-0A.is.legal": true,
 
 		"1":                   false,
 		"1.2":                 false,
@@ -122,7 +154,7 @@ func testSemVer(t *testing.T, version string, isSemVer bool) {
 
 	if isSemVer {
 		require.NoError(t, err)
-		require.Equal(t, version, v)
+		require.Equal(t, strings.TrimPrefix(version, "v"), v)
 	} else {
 		require.Error(t, err)
 		require.Equal(t, "", v)


### PR DESCRIPTION
but trim that before sending it to the backend