### PR TITLE
Chart and app versions

### DIFF
--- a/charts/cbcontainers-agent/README.md
+++ b/charts/cbcontainers-agent/README.md
@@ -42,7 +42,7 @@ The way that the CBC Containers components are installed is highly customizable.
 
 You can set different properties for the components or enable/disable components via the `spec.components` section of your `values.yaml` file.
 
-For all the possible values see <https://github.com/octarinesec/octarine-operator/blob/master/docs%2Fcrds.md#basic-components-optional-parameters>.
+For all the possible values see <https://github.com/octarinesec/octarine-operator/blob/master/docs%2Fcrds.md#basic-components-optional-parameters> and [`example-value.yaml`](cbcontainers-agent-chart/example-values.yaml).
 
 ### Secret creation
 

--- a/charts/cbcontainers-agent/cbcontainers-agent-chart/Chart.yaml
+++ b/charts/cbcontainers-agent/cbcontainers-agent-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cbcontainers-agent-chart
 description: A Helm chart for installing the CBContainers Agent
 type: application
-version: 0.1.0
-appVersion: "3.0.0"
+version: 1.0.0
+appVersion: "2.4.0"

--- a/charts/cbcontainers-agent/cbcontainers-agent-chart/example-values.yaml
+++ b/charts/cbcontainers-agent/cbcontainers-agent-chart/example-values.yaml
@@ -1,9 +1,12 @@
+# this is an example file with all possible values
+# that can be used for the customization of the cbcontainers-agent chart
+
 # accessToken is the API token used by the agent to communicate with the backend
 accessToken: ""
 # orgKey is the ID of the organization account
 orgKey: "ABC123"
 # version is the version of the agent that will be installed
-version: "2.3.1"
+version: "2.4.0"
 # clusterGroup is the group that the cluster will belong to.
 clusterGroup: "default"
 # clusterName is the name that will be used for the cluster that the agent is installed on

--- a/charts/cbcontainers-agent/cbcontainers-agent-chart/values.yaml
+++ b/charts/cbcontainers-agent/cbcontainers-agent-chart/values.yaml
@@ -3,7 +3,7 @@ accessToken: ""
 # orgKey is the ID of the organization account
 orgKey: ""
 # version is the version of the agent that will be installed
-version: "2.3.1"
+version: "2.4.0"
 # clusterGroup is the group that the cluster will belong to.
 clusterGroup: ""
 # clusterName is the name that will be used for the cluster that the agent is installed on

--- a/charts/cbcontainers-operator/cbcontainers-operator-chart/Chart.yaml
+++ b/charts/cbcontainers-operator/cbcontainers-operator-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cbcontainers-operator
 description: A Helm chart for installing the CBContainers operator
 type: application
-version: 0.1.0
+version: 1.0.0
 appVersion: v5.1.0


### PR DESCRIPTION
- set both chart versions to `1.0.0` because this is the initial release of the charts
- set appVersions to `2.4.0` and `5.1.0`, because these are the latest versions of the agent and operator
- add some more documentation for `example-values.yaml`