### PR TITLE
GRC-1599 | dedicated roles for the agent components

### DIFF
--- a/cbcontainers/state/common/dataplane_consts.go
+++ b/cbcontainers/state/common/dataplane_consts.go
@@ -3,10 +3,16 @@ package common
 const (
 	DataPlaneNamespaceName = "cbcontainers-dataplane"
 
-	DataPlaneConfigmapName      = "cbcontainers-dataplane-config"
-	RegistrySecretName          = "cbcontainers-registry-secret"
-	DataPlaneServiceAccountName = "cbcontainers-operator"
-	DataPlanePriorityClassName  = "cbcontainers-dataplane-priority-class"
+	DataPlaneConfigmapName            = "cbcontainers-dataplane-config"
+	RegistrySecretName                = "cbcontainers-registry-secret"
+	DataPlaneServiceAccountName       = "cbcontainers-operator"
+	AgentServiceAccountName           = "cbcontainers-agent"
+	StateReporterServiceAccountName   = "cbcontainers-state-reporter"
+	EnforcerServiceAccountName        = "cbcontainers-enforcer"
+	MonitorServiceAccountName         = "cbcontainers-monitor"
+	ImageScanningServiceAccountName   = "cbcontainers-image-scanning"
+	RuntimeResolverServiceAccountName = "cbcontainers-runtime-resolver"
+	DataPlanePriorityClassName        = "cbcontainers-dataplane-priority-class"
 
 	DataPlaneConfigmapAccountKey        = "Account"
 	DataPlaneConfigmapClusterKey        = "Cluster"

--- a/cbcontainers/state/common/dataplane_consts.go
+++ b/cbcontainers/state/common/dataplane_consts.go
@@ -6,7 +6,7 @@ const (
 	DataPlaneConfigmapName            = "cbcontainers-dataplane-config"
 	RegistrySecretName                = "cbcontainers-registry-secret"
 	DataPlaneServiceAccountName       = "cbcontainers-operator"
-	AgentServiceAccountName           = "cbcontainers-agent"
+	AgentNodeServiceAccountName       = "cbcontainers-agent-node"
 	StateReporterServiceAccountName   = "cbcontainers-state-reporter"
 	EnforcerServiceAccountName        = "cbcontainers-enforcer"
 	MonitorServiceAccountName         = "cbcontainers-monitor"

--- a/cbcontainers/state/components/enforcer_deployment.go
+++ b/cbcontainers/state/components/enforcer_deployment.go
@@ -73,7 +73,7 @@ func (obj *EnforcerDeploymentK8sObject) MutateK8sObject(k8sObject client.Object,
 	deployment.ObjectMeta.Labels = desiredLabels
 	deployment.Spec.Selector.MatchLabels = desiredLabels
 	deployment.Spec.Template.ObjectMeta.Labels = desiredLabels
-	deployment.Spec.Template.Spec.ServiceAccountName = commonState.DataPlaneServiceAccountName
+	deployment.Spec.Template.Spec.ServiceAccountName = commonState.EnforcerServiceAccountName
 	deployment.Spec.Template.Spec.PriorityClassName = commonState.DataPlanePriorityClassName
 	deployment.Spec.Template.Spec.ImagePullSecrets = []coreV1.LocalObjectReference{{Name: commonState.RegistrySecretName}}
 	obj.mutateAnnotations(deployment, enforcer)

--- a/cbcontainers/state/components/image_scanning_reporter_deployment.go
+++ b/cbcontainers/state/components/image_scanning_reporter_deployment.go
@@ -77,7 +77,7 @@ func (obj *ImageScanningReporterDeploymentK8sObject) initiateDeployment(deployme
 	}
 
 	deployment.Spec.Replicas = imageScanningReporter.ReplicasCount
-	deployment.Spec.Template.Spec.ServiceAccountName = commonState.DataPlaneServiceAccountName
+	deployment.Spec.Template.Spec.ServiceAccountName = commonState.ImageScanningServiceAccountName
 	deployment.Spec.Template.Spec.PriorityClassName = commonState.DataPlanePriorityClassName
 	deployment.Spec.Template.Spec.ImagePullSecrets = []coreV1.LocalObjectReference{{Name: commonState.RegistrySecretName}}
 }

--- a/cbcontainers/state/components/monitor_deployment.go
+++ b/cbcontainers/state/components/monitor_deployment.go
@@ -70,7 +70,7 @@ func (obj *MonitorDeploymentK8sObject) MutateK8sObject(k8sObject client.Object, 
 	deployment.ObjectMeta.Labels = desiredLabels
 	deployment.Spec.Selector.MatchLabels = desiredLabels
 	deployment.Spec.Template.ObjectMeta.Labels = desiredLabels
-	deployment.Spec.Template.Spec.ServiceAccountName = commonState.DataPlaneServiceAccountName
+	deployment.Spec.Template.Spec.ServiceAccountName = commonState.MonitorServiceAccountName
 	deployment.Spec.Template.Spec.PriorityClassName = commonState.DataPlanePriorityClassName
 	applyment.EnforceMapContains(deployment.ObjectMeta.Annotations, monitor.DeploymentAnnotations)
 	applyment.EnforceMapContains(deployment.Spec.Template.ObjectMeta.Annotations, monitor.PodTemplateAnnotations)

--- a/cbcontainers/state/components/runtime_resolver_deployment.go
+++ b/cbcontainers/state/components/runtime_resolver_deployment.go
@@ -74,7 +74,7 @@ func (obj *ResolverDeploymentK8sObject) MutateK8sObject(k8sObject client.Object,
 	deployment.ObjectMeta.Labels = desiredLabels
 	deployment.Spec.Selector.MatchLabels = desiredLabels
 	deployment.Spec.Template.ObjectMeta.Labels = desiredLabels
-	deployment.Spec.Template.Spec.ServiceAccountName = commonState.DataPlaneServiceAccountName
+	deployment.Spec.Template.Spec.ServiceAccountName = commonState.RuntimeResolverServiceAccountName
 	deployment.Spec.Template.Spec.PriorityClassName = commonState.DataPlanePriorityClassName
 	deployment.Spec.Template.Spec.ImagePullSecrets = []coreV1.LocalObjectReference{{Name: commonState.RegistrySecretName}}
 	obj.mutateAnnotations(deployment, resolver)

--- a/cbcontainers/state/components/sensor_daemon_set.go
+++ b/cbcontainers/state/components/sensor_daemon_set.go
@@ -117,7 +117,7 @@ func (obj *SensorDaemonSetK8sObject) initiateDamonSet(daemonSet *appsV1.DaemonSe
 		daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
 
-	daemonSet.Spec.Template.Spec.ServiceAccountName = commonState.DataPlaneServiceAccountName
+	daemonSet.Spec.Template.Spec.ServiceAccountName = commonState.AgentServiceAccountName
 	daemonSet.Spec.Template.Spec.PriorityClassName = commonState.DataPlanePriorityClassName
 	daemonSet.Spec.Template.Spec.ImagePullSecrets = []coreV1.LocalObjectReference{{Name: commonState.RegistrySecretName}}
 }

--- a/cbcontainers/state/components/sensor_daemon_set.go
+++ b/cbcontainers/state/components/sensor_daemon_set.go
@@ -117,7 +117,7 @@ func (obj *SensorDaemonSetK8sObject) initiateDamonSet(daemonSet *appsV1.DaemonSe
 		daemonSet.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
 
-	daemonSet.Spec.Template.Spec.ServiceAccountName = commonState.AgentServiceAccountName
+	daemonSet.Spec.Template.Spec.ServiceAccountName = commonState.AgentNodeServiceAccountName
 	daemonSet.Spec.Template.Spec.PriorityClassName = commonState.DataPlanePriorityClassName
 	daemonSet.Spec.Template.Spec.ImagePullSecrets = []coreV1.LocalObjectReference{{Name: commonState.RegistrySecretName}}
 }

--- a/cbcontainers/state/components/state_reporter_deployment.go
+++ b/cbcontainers/state/components/state_reporter_deployment.go
@@ -71,7 +71,7 @@ func (obj *StateReporterDeploymentK8sObject) MutateK8sObject(k8sObject client.Ob
 	deployment.ObjectMeta.Labels = desiredLabels
 	deployment.Spec.Selector.MatchLabels = desiredLabels
 	deployment.Spec.Template.ObjectMeta.Labels = desiredLabels
-	deployment.Spec.Template.Spec.ServiceAccountName = commonState.DataPlaneServiceAccountName
+	deployment.Spec.Template.Spec.ServiceAccountName = commonState.StateReporterServiceAccountName
 	deployment.Spec.Template.Spec.PriorityClassName = commonState.DataPlanePriorityClassName
 	applyment.EnforceMapContains(deployment.ObjectMeta.Annotations, stateReporter.DeploymentAnnotations)
 	applyment.EnforceMapContains(deployment.Spec.Template.ObjectMeta.Annotations, stateReporter.PodTemplateAnnotations)

--- a/config/rbac/dataplane_roles.yaml
+++ b/config/rbac/dataplane_roles.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: monitor-role
+rules:
+  - apiGroups:
+      - ""
+      - apps
+      - admissionregistration.k8s.io
+    resources:
+      - daemonsets
+      - deployments
+      - nodes
+      - pods
+      - replicasets
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: agent-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: enforcer-role
+rules:
+  - apiGroups:
+      - apps
+      - batch
+    resources:
+      - jobs
+      - replicasets
+    verbs:
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: image-scanning-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: runtime-resolver-role
+rules:
+  - apiGroups:
+      - ""
+      - discovery.k8s.io
+      - apps
+      - batch
+    resources:
+      - endpoints
+      - endpointslices
+      - jobs
+      - nodes
+      - pods
+      - replicasets
+      - services
+    verbs:
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: state-reporter-role
+rules:
+  - apiGroups:
+      - ""
+      - apiextensions.k8s.io
+      - apps
+      - batch
+      - extensions
+      - networking.k8s.io
+      - rbac
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - cronjobs
+      - customresourcedefinitions
+      - daemonsets
+      - deployments
+      - ingresses
+      - jobs
+      - namespaces
+      - nodes
+      - pods
+      - replicasets
+      - replicationcontrollers
+      - rolebindings
+      - services
+      - statefulsets
+    verbs:
+      - watch

--- a/config/rbac/dataplane_roles.yaml
+++ b/config/rbac/dataplane_roles.yaml
@@ -24,7 +24,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: agent-role
+  name: agent-node-role
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - role.yaml
+- dataplane_roles.yaml
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,53 +7,12 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
-  - discovery.k8s.io
-  resources:
-  - endpoints
-  - endpointslices
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
   - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  - apps
-  - batch
-  - ""
-  - extensions
-  - networking.k8s.io
-  - rbac
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - cronjobs
-  - customresourcedefinitions
-  - daemonsets
-  - deployments
-  - ingresses
-  - jobs
-  - namespaces
-  - networkpolicies
-  - nodes
-  - pods
-  - replicasets
-  - replicationcontrollers
-  - rolebindings
-  - services
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - apps
   - ""
@@ -82,6 +41,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
 - apiGroups:
   - operator.containers.carbonblack.io
   resources:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -10,3 +10,81 @@ subjects:
 - kind: ServiceAccount
   name: operator
   namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: state-reporter-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: state-reporter-role
+subjects:
+  - kind: ServiceAccount
+    name: state-reporter
+    namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: enforcer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enforcer-role
+subjects:
+  - kind: ServiceAccount
+    name: enforcer
+    namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitor-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitor-role
+subjects:
+  - kind: ServiceAccount
+    name: monitor
+    namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: image-scanning-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: image-scanning-role
+subjects:
+  - kind: ServiceAccount
+    name: image-scanning
+    namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: runtime-resolver-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: runtime-resolver-role
+subjects:
+  - kind: ServiceAccount
+    name: runtime-resolver
+    namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-role
+subjects:
+  - kind: ServiceAccount
+    name: agent
+    namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -79,12 +79,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: agent-rolebinding
+  name: agent-node-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: agent-role
+  name: agent-node-role
 subjects:
   - kind: ServiceAccount
-    name: agent
+    name: agent-node
     namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -58,7 +58,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: agent
+  name: agent-node
   namespace: system
 imagePullSecrets:
   - name: cbcontainers-operator-public-registry-secret

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -14,3 +14,52 @@ metadata:
   namespace: system
 imagePullSecrets:
   - name: cbcontainers-operator-public-registry-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: state-reporter
+  namespace: system
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enforcer
+  namespace: system
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: monitor
+  namespace: system
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-scanning
+  namespace: system
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: runtime-resolver
+  namespace: system
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent
+  namespace: system
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+

--- a/controllers/cbcontainersagent_controller.go
+++ b/controllers/cbcontainersagent_controller.go
@@ -79,8 +79,7 @@ func (r *CBContainersAgentController) getContainersAgentObject(ctx context.Conte
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=*
 // +kubebuilder:rbac:groups={apps,core},resources={deployments,services,daemonsets},verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources={validatingwebhookconfigurations,mutatingwebhookconfigurations},verbs=*
-// +kubebuilder:rbac:groups={rbac.authorization.k8s.io,networking.k8s.io,apiextensions.k8s.io,extensions,rbac,batch,apps,core},resources={namespaces,clusterrolebindings,services,networkpolicies,ingresses,rolebindings,cronjobs,jobs,replicationcontrollers,statefulsets,daemonsets,deployments,replicasets,pods,nodes,customresourcedefinitions},verbs=get;list;watch
-// +kubebuilder:rbac:groups={discovery.k8s.io,""},resources={services,endpoints,endpointslices},verbs=get;list;watch
+// +kubebuilder:rbac:groups={core},resources={nodes},verbs=list
 // +kubebuilder:rbac:groups={policy},resources={podsecuritypolicies},verbs=use,resourceNames={cbcontainers-manager-psp}
 
 func (r *CBContainersAgentController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Split and create roles for each dataplane component:

- ServiceAccount
- ClusterRole
- ClusterRoleBinding