### PR TITLE
GRC-2458 Omit kube-system in mutating webhook

### DIFF
--- a/cbcontainers/state/common/dataplane_consts.go
+++ b/cbcontainers/state/common/dataplane_consts.go
@@ -1,7 +1,8 @@
 package common
 
 const (
-	DataPlaneNamespaceName = "cbcontainers-dataplane"
+	DataPlaneNamespaceName  = "cbcontainers-dataplane"
+	KubeSystemNamespaceName = "kube-system"
 
 	DataPlaneConfigmapName            = "cbcontainers-dataplane-config"
 	RegistrySecretName                = "cbcontainers-registry-secret"

--- a/cbcontainers/state/components/enforcer_mutating_webhook.go
+++ b/cbcontainers/state/components/enforcer_mutating_webhook.go
@@ -130,7 +130,7 @@ func (obj *EnforcerMutatingWebhookK8sObject) getResourcesNamespaceSelector(selec
 	cbContainersNamespace := metav1.LabelSelectorRequirement{
 		Key:      "name",
 		Operator: metav1.LabelSelectorOpNotIn,
-		Values:   []string{commonState.DataPlaneNamespaceName},
+		Values:   []string{commonState.DataPlaneNamespaceName, commonState.KubeSystemNamespaceName},
 	}
 
 	initializeLabelSelector := false

--- a/cbcontainers/state/components/enforcer_mutating_webhook.go
+++ b/cbcontainers/state/components/enforcer_mutating_webhook.go
@@ -68,7 +68,7 @@ func (obj *EnforcerMutatingWebhookK8sObject) mutateWebhooks(webhookConfiguration
 
 	initializeWebhooks := false
 	webhooks := webhookConfiguration.GetWebhooks()
-	if webhooks == nil || len(webhooks) != 2 {
+	if webhooks == nil || len(webhooks) != 1 {
 		initializeWebhooks = true
 	} else {
 		resourcesWebhook, resourcesWebhookFound := obj.findWebhookByName(webhooks, MutatingWebhookName)

--- a/cbcontainers/state/components/enforcer_validating_webhook.go
+++ b/cbcontainers/state/components/enforcer_validating_webhook.go
@@ -229,6 +229,9 @@ func (obj *EnforcerValidatingWebhookK8sObject) mutateNamespacesWebhook(namespace
 }
 
 func (obj *EnforcerValidatingWebhookK8sObject) mutateNamespacesWebhooksRules(webhook adapters.WebhookAdapter) {
+	// This webhook exists to prevent someone from adding the "octarine:ignore" label on a namespace (except ours)
+	// Which would essentially disable our product there
+	// So we have a separate webhook call for all namespaces and the agent will forbid the request if the label is added
 	rules := webhook.GetAdmissionRules()
 	if rules == nil || len(rules) != 1 {
 		rules = make([]adapters.AdmissionRuleAdapter, 1)

--- a/controllers/cbcontainersagent_controller.go
+++ b/controllers/cbcontainersagent_controller.go
@@ -156,5 +156,6 @@ func (r *CBContainersAgentController) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&appsV1.DaemonSet{}).
 		Owns(adapters.EmptyValidatingWebhookConfigForVersion(r.K8sVersion)).
+		Owns(adapters.EmptyMutatingWebhookConfigForVersion(r.K8sVersion)).
 		Complete(r)
 }


### PR DESCRIPTION
Functional changes:
1. Disable the enforce feature in kube-system to prevent accidentally brining down the cluster (by ignoring it in the webhook)

Bugfixes:

1. Operator was running in a constant reconcile loop because it was looking for 2 mutating webhooks while we only create 1
2. Set the operator to watch for mutatingwebhook objects so it can reconcile properly if needed

Minors:
Added a comment on why we have 2 webhooks in the validation phase as I *always* forget. 