### PR TITLE
Fix broken reconcile loop and default value for Enforcement feature on v1beta1 clusters (1.13-1.15)

### DIFF
--- a/api/v1/hardening_types.go
+++ b/api/v1/hardening_types.go
@@ -51,7 +51,7 @@ type CBContainersEnforcerSpec struct {
 	// +kubebuilder:default:=5
 	WebhookTimeoutSeconds int32 `json:"webhookTimeoutSeconds,omitempty"`
 	// +kubebuilder:default:=true
-	EnableEnforcementFeature bool `json:"enableEnforcementFeature,omitempty"`
+	EnableEnforcementFeature *bool `json:"enableEnforcementFeature,omitempty"`
 	// +kubebuilder:validation:Enum=Ignore;Fail
 	// +kubebuilder:default:=Ignore
 	FailurePolicy string `json:"failurePolicy,omitempty"`

--- a/cbcontainers/processors/default_gateway_creator.go
+++ b/cbcontainers/processors/default_gateway_creator.go
@@ -27,7 +27,7 @@ func (creator *DefaultGatewayCreator) CreateGateway(cbContainersAgent *cbcontain
 		builder.WithClusterScanning()
 	}
 
-	if spec.Components.Basic.Enforcer.EnableEnforcementFeature {
+	if spec.Components.Basic.Enforcer.EnableEnforcementFeature != nil && *spec.Components.Basic.Enforcer.EnableEnforcementFeature {
 		builder.WithGuardrailsEnforce()
 	}
 

--- a/cbcontainers/state/components/enforcer_mutating_webhook.go
+++ b/cbcontainers/state/components/enforcer_mutating_webhook.go
@@ -104,15 +104,15 @@ func (obj *EnforcerMutatingWebhookK8sObject) findWebhookByName(webhooks []adapte
 
 func (obj *EnforcerMutatingWebhookK8sObject) mutateResourcesWebhook(resourcesWebhook adapters.WebhookAdapter, timeoutSeconds int32, failurePolicy string) {
 	resourcesWebhook.SetName(MutatingWebhookName)
-	resourcesWebhook.SetAdmissionReviewVersions([]string{"v1beta1"})
 	resourcesWebhook.SetFailurePolicy(failurePolicy)
 	resourcesWebhook.SetSideEffects(MutatingWebhookSideEffect)
-	resourcesWebhook.SetMatchPolicy(MutatingWebhookMatchPolicy)
 	namespaceSelector := obj.getResourcesNamespaceSelector(resourcesWebhook.GetNamespaceSelector())
 	resourcesWebhook.SetNamespaceSelector(namespaceSelector)
 	obj.mutateMutatingWebhooksRules(resourcesWebhook)
 	if obj.kubeletVersion == "" || obj.kubeletVersion >= "v1.14" {
 		resourcesWebhook.SetTimeoutSeconds(timeoutSeconds)
+		resourcesWebhook.SetMatchPolicy(MutatingWebhookMatchPolicy)
+		resourcesWebhook.SetAdmissionReviewVersions([]string{"v1beta1"})
 	}
 	resourcesWebhook.SetCABundle(obj.tlsSecretValues.CaCert)
 	resourcesWebhook.SetServiceName(EnforcerName)

--- a/cbcontainers/state/components/enforcer_validating_webhook.go
+++ b/cbcontainers/state/components/enforcer_validating_webhook.go
@@ -112,15 +112,15 @@ func (obj *EnforcerValidatingWebhookK8sObject) findWebhookByName(webhooks []adap
 
 func (obj *EnforcerValidatingWebhookK8sObject) mutateResourcesWebhook(resourcesWebhook adapters.WebhookAdapter, timeoutSeconds int32, failurePolicy string) {
 	resourcesWebhook.SetName(ValidatingResourcesWebhookName)
-	resourcesWebhook.SetAdmissionReviewVersions([]string{"v1beta1"})
 	resourcesWebhook.SetFailurePolicy(failurePolicy)
 	resourcesWebhook.SetSideEffects(ResourcesWebhookSideEffect)
-	resourcesWebhook.SetMatchPolicy(WebhookMatchPolicy)
 	namespaceSelector := obj.getResourcesNamespaceSelector(resourcesWebhook.GetNamespaceSelector())
 	resourcesWebhook.SetNamespaceSelector(namespaceSelector)
 	obj.mutateResourcesWebhooksRules(resourcesWebhook)
 	if obj.kubeletVersion == "" || obj.kubeletVersion >= "v1.14" {
 		resourcesWebhook.SetTimeoutSeconds(timeoutSeconds)
+		resourcesWebhook.SetMatchPolicy(WebhookMatchPolicy)
+		resourcesWebhook.SetAdmissionReviewVersions([]string{"v1beta1"})
 	}
 	resourcesWebhook.SetCABundle(obj.tlsSecretValues.CaCert)
 	resourcesWebhook.SetServiceName(EnforcerName)
@@ -213,13 +213,14 @@ func (obj *EnforcerValidatingWebhookK8sObject) getResourcesList() []string {
 
 func (obj *EnforcerValidatingWebhookK8sObject) mutateNamespacesWebhook(namespacesWebhook adapters.WebhookAdapter, timeoutSeconds int32, failurePolicy string) {
 	namespacesWebhook.SetName(ValidatingNamespacesWebhookName)
-	namespacesWebhook.SetAdmissionReviewVersions([]string{"v1beta1"})
 	namespacesWebhook.SetFailurePolicy(failurePolicy)
-	namespacesWebhook.SetMatchPolicy(WebhookMatchPolicy)
 	namespacesWebhook.SetSideEffects(NamespacesWebhookSideEffect)
 	namespacesWebhook.SetNamespaceSelector(&metav1.LabelSelector{})
 	if obj.kubeletVersion == "" || obj.kubeletVersion >= "v1.14" {
+		// Fields introduced to v1beta1 in 1.14
 		namespacesWebhook.SetTimeoutSeconds(timeoutSeconds)
+		namespacesWebhook.SetMatchPolicy(WebhookMatchPolicy)
+		namespacesWebhook.SetAdmissionReviewVersions([]string{"v1beta1"})
 	}
 
 	namespacesWebhook.SetCABundle(obj.tlsSecretValues.CaCert)

--- a/cbcontainers/state/state_applier.go
+++ b/cbcontainers/state/state_applier.go
@@ -333,7 +333,7 @@ func (c *StateApplier) applyEnforcerWebhooks(ctx context.Context, agentSpec *cbc
 	}
 
 	mutatedMutatingWebhook := false
-	if agentSpec.Components.Basic.Enforcer.EnableEnforcementFeature {
+	if agentSpec.Components.Basic.Enforcer.EnableEnforcementFeature != nil && *agentSpec.Components.Basic.Enforcer.EnableEnforcementFeature {
 		c.enforcerMutatingWebhook.UpdateTlsSecretValues(tlsSecretValues)
 		mutatedMutatingWebhook, _, err = c.applier.Apply(ctx, c.enforcerMutatingWebhook, agentSpec, applyOptions)
 		if err != nil {

--- a/cbcontainers/state/state_applier.go
+++ b/cbcontainers/state/state_applier.go
@@ -348,6 +348,7 @@ func (c *StateApplier) applyEnforcerWebhooks(ctx context.Context, agentSpec *cbc
 		mutatedMutatingWebhook = deletedWebhookDueToDisabledFlag
 	}
 
+	c.log.Info("Applied enforcer webhooks", "Mutated validated webhook", mutatedValidatingWebhook, "Mutated mutating webhook", mutatedMutatingWebhook)
 	return mutatedValidatingWebhook || mutatedMutatingWebhook, nil
 }
 

--- a/cbcontainers/state/state_applier_test.go
+++ b/cbcontainers/state/state_applier_test.go
@@ -292,7 +292,7 @@ func TestEnforcerWebhooksAreApplied(t *testing.T) {
 		t.Helper()
 
 		withMutatingWebhook := func(mocks *StateApplierTestMocks) {
-			mocks.agentSpec.Components.Basic.Enforcer.EnableEnforcementFeature = true
+			mocks.agentSpec.Components.Basic.Enforcer.EnableEnforcementFeature = &trueRef
 		}
 
 		t.Run("With default spec, should apply the validating webhook and delete the mutating webhook", func(t *testing.T) {

--- a/controllers/basic_components_defaults.go
+++ b/controllers/basic_components_defaults.go
@@ -86,6 +86,10 @@ func (r *CBContainersAgentController) setEnforcerDefaults(enforcer *cbcontainers
 		enforcer.FailurePolicy = "Ignore"
 	}
 
+	if enforcer.EnableEnforcementFeature == nil {
+		enforcer.EnableEnforcementFeature = &trueRef
+	}
+
 	return nil
 }
 


### PR DESCRIPTION

The enforcement default was not applied to 1.13-1.15 clusters as v1beta1 CRDs don't support default values in YAML (so we set them manually).

I also noticed that on 1.13 2 fields do not exist in the webhook definition, causing an infinite reconcile as the controller always saw a difference in the applied vs expected object. 