### PR TITLE
Install the PSP on Kubernetes 1.24 and earlier only

### DIFF
--- a/charts/cbcontainers-operator/cbcontainers-operator-chart/Chart.yaml
+++ b/charts/cbcontainers-operator/cbcontainers-operator-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: cbcontainers-operator
 description: A Helm chart for installing the CBContainers operator
 type: application
 version: 1.0.0
-appVersion: v5.3.0
+appVersion: v5.3.1

--- a/charts/cbcontainers-operator/cbcontainers-operator-chart/templates/operator.yaml
+++ b/charts/cbcontainers-operator/cbcontainers-operator-chart/templates/operator.yaml
@@ -4496,6 +4496,7 @@ kind: ServiceAccount
 metadata:
   name: cbcontainers-operator
   namespace: cbcontainers-dataplane
+{{- if and (eq (int .Capabilities.KubeVersion.Major) 1) (lt (int .Capabilities.KubeVersion.Minor) 25) }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -4519,6 +4520,7 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,4 +12,3 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 # - auth_proxy_client_clusterrole.yaml
-- pod_security_policy.yaml

--- a/operator_psp.yaml
+++ b/operator_psp.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: manager-psp
+  name: cbcontainers-manager-psp
 spec:
   privileged: true
   hostPID: true


### PR DESCRIPTION
This allows the operator to be installed on Kubernetes 1.25+, where PSPs are not available. The operator PodSecurityPolicy will continue to be installed and be available for Kubernetes 1.24 and earlier.