### PR TITLE
Fix helm chart installation

### DIFF
--- a/charts/cbcontainers-agent/README.md
+++ b/charts/cbcontainers-agent/README.md
@@ -10,30 +10,30 @@ In order for the chart to be installed it needs minimal configuration.
 
 There are 8 required fields that need to be provided by the user:
 
-| Parameter                                              | Description                                                      |
-| ------------------------------------------------------ | ---------------------------------------------------------------- |
-| `spec.orgKey`                                       | The org key of the organization using CBC                     |
-| `spec.clusterName`                                     | The name of the cluster that will be added to CBC                |
-| `spec.clusterGroup`                                    | The group that the cluster belongs to in CBC                     |
-| `spec.version`                                         | The version of the agent images                                  |
-| `spec.gateways.apiGatewayHost`                         | The URL of the CBC API Gateway                                   |
-| `spec.gateways.coreEventsGatewayHost`                  | The URL of the CBC Core events Gateway                           |
-| `spec.gateways.hardeningEventsGatewayHost`             | The URL of the CBC Hardening events Gateway                      |
-| `spec.gateways.runtimeEventsGatewayHost`               | The URL of the CBC Runtime events Gateway                        |
+| Parameter                                  | Description                                       |
+|--------------------------------------------|---------------------------------------------------|
+| `spec.orgKey`                              | The org key of the organization using CBC         |
+| `spec.clusterName`                         | The name of the cluster that will be added to CBC |
+| `spec.clusterGroup`                        | The group that the cluster belongs to in CBC      |
+| `spec.version`                             | The version of the agent images                   |
+| `spec.gateways.apiGatewayHost`             | The URL of the CBC API Gateway                    |
+| `spec.gateways.coreEventsGatewayHost`      | The URL of the CBC Core events Gateway            |
+| `spec.gateways.hardeningEventsGatewayHost` | The URL of the CBC Hardening events Gateway       |
+| `spec.gateways.runtimeEventsGatewayHost`   | The URL of the CBC Runtime events Gateway         |
 
 After setting these required fields in a `values.yaml` file you can install the chart from our repo:
 
 ```sh
 helm repo add vmware TODO-chart-repo/TODO-chart-name -f values.yaml
 helm repo update
-helm install cbcontainers-agent TODO-chart-repo/TODO-chart-name -f values.yaml
+helm install cbcontainers-agent TODO-chart-repo/TODO-chart-name -f values.yaml --namespace cbcontainers-dataplane
 ```
 
 or from source
 
 ```sh
 cd charts/cbcontainers-agent
-helm install cbcontainers-agent ./cbcontainers-agent-chart -f values.yaml
+helm install cbcontainers-agent ./cbcontainers-agent-chart -f values.yaml --namespace cbcontainers-dataplane
 ```
 
 ## Customization

--- a/charts/cbcontainers-agent/cbcontainers-agent-chart/templates/rbac.yaml
+++ b/charts/cbcontainers-agent/cbcontainers-agent-chart/templates/rbac.yaml
@@ -1,0 +1,178 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cbcontainers-agent-node-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cbcontainers-enforcer-role
+rules:
+  - apiGroups:
+      - apps
+      - batch
+    resources:
+      - jobs
+      - replicasets
+    verbs:
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cbcontainers-image-scanning-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cbcontainers-monitor-role
+rules:
+  - apiGroups:
+      - ""
+      - apps
+      - admissionregistration.k8s.io
+    resources:
+      - daemonsets
+      - deployments
+      - nodes
+      - pods
+      - replicasets
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cbcontainers-runtime-resolver-role
+rules:
+  - apiGroups:
+      - ""
+      - discovery.k8s.io
+      - apps
+      - batch
+    resources:
+      - endpoints
+      - endpointslices
+      - jobs
+      - nodes
+      - pods
+      - replicasets
+      - services
+    verbs:
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cbcontainers-state-reporter-role
+rules:
+  - apiGroups:
+      - ""
+      - apiextensions.k8s.io
+      - apps
+      - batch
+      - extensions
+      - networking.k8s.io
+      - rbac
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - cronjobs
+      - customresourcedefinitions
+      - daemonsets
+      - deployments
+      - ingresses
+      - jobs
+      - namespaces
+      - nodes
+      - pods
+      - replicasets
+      - replicationcontrollers
+      - rolebindings
+      - services
+      - statefulsets
+    verbs:
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cbcontainers-agent-node-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cbcontainers-agent-node-role
+subjects:
+  - kind: ServiceAccount
+    name: cbcontainers-agent-node
+    namespace: cbcontainers-dataplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cbcontainers-enforcer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cbcontainers-enforcer-role
+subjects:
+  - kind: ServiceAccount
+    name: cbcontainers-enforcer
+    namespace: cbcontainers-dataplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cbcontainers-image-scanning-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cbcontainers-image-scanning-role
+subjects:
+  - kind: ServiceAccount
+    name: cbcontainers-image-scanning
+    namespace: cbcontainers-dataplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cbcontainers-monitor-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cbcontainers-monitor-role
+subjects:
+  - kind: ServiceAccount
+    name: cbcontainers-monitor
+    namespace: cbcontainers-dataplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cbcontainers-runtime-resolver-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cbcontainers-runtime-resolver-role
+subjects:
+  - kind: ServiceAccount
+    name: cbcontainers-runtime-resolver
+    namespace: cbcontainers-dataplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cbcontainers-state-reporter-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cbcontainers-state-reporter-role
+subjects:
+  - kind: ServiceAccount
+    name: cbcontainers-state-reporter
+    namespace: cbcontainers-dataplane

--- a/charts/cbcontainers-agent/cbcontainers-agent-chart/templates/service-accounts.yaml
+++ b/charts/cbcontainers-agent/cbcontainers-agent-chart/templates/service-accounts.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+kind: ServiceAccount
+metadata:
+  name: cbcontainers-agent-node
+  namespace: cbcontainers-dataplane
+---
+apiVersion: v1
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+kind: ServiceAccount
+metadata:
+  name: cbcontainers-enforcer
+  namespace: cbcontainers-dataplane
+---
+apiVersion: v1
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+kind: ServiceAccount
+metadata:
+  name: cbcontainers-image-scanning
+  namespace: cbcontainers-dataplane
+---
+apiVersion: v1
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+kind: ServiceAccount
+metadata:
+  name: cbcontainers-monitor
+  namespace: cbcontainers-dataplane
+---
+apiVersion: v1
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+kind: ServiceAccount
+metadata:
+  name: cbcontainers-runtime-resolver
+  namespace: cbcontainers-dataplane
+---
+apiVersion: v1
+imagePullSecrets:
+  - name: cbcontainers-operator-public-registry-secret
+kind: ServiceAccount
+metadata:
+  name: cbcontainers-state-reporter
+  namespace: cbcontainers-dataplane

--- a/charts/cbcontainers-operator/README.md
+++ b/charts/cbcontainers-operator/README.md
@@ -8,28 +8,53 @@ Helm 3 is supported.
 
 The chart can be installed as is, without any customization or modifications.
 
+### Choosing a namespace for the helm release
+Currently, the charts do not support running outside the `cbcontainers-dataplane` namespace, and they create and label that namespace as needed. 
+Therefore, there are two options for choosing the namespace for the actual helm release - creating the `cbcontainers-dataplane` namespace and "adopting" it via Helm _or_ installing the release in another namespace.
+
+**Option 1**: Using `cbcontainers-dataplane` to manage the release (recommended)
+
+Run the following commands to prepare the release namespace
+```sh
+kubectl create namespace cbcontainers-dataplane
+kubectl annotate namespace cbcontainers-dataplane meta.helm.sh/release-name=cbcontainers-operator meta.helm.sh/release-namespace=cbcontainers-dataplane
+kubectl label namespace cbcontainers-dataplane app.kubernetes.io/managed-by=Helm
+```
+
+And use `cbcontainers-dataplane` in all commands below that require a namespace (`--namespace X`).
+With this option, future commands like `helm install`, `helm list` should be run in the context of the `cbcontainers-dataplane` namespace. 
+
+**Option 2**: Using a different namespace to manage the release
+
+Choose a namespace that exists in the cluster - `my-namespace` and use that for all commands that require a namespace below (`--namespace X`).
+Note that in this case the resources are still installed in `cbcontainers-dataplane` namespace but the actual helm release does not live there.
+With this option, future commands like `helm install`, `helm list`, etc. must be run in the context of the chosen namespace `my-namespace`. 
+
+### Installing the operator chart
+Now, install the actual helm chart in the namespace based on the chosen option 1 or 2 above.
+
 ```sh
 helm repo add vmware TODO-chart-repo/TODO-chart-name
 helm repo update
-helm install cbcontainers-operator TODO-chart-repo/TODO-chart-name
+helm install cbcontainers-operator TODO-chart-repo/TODO-chart-name --namespace X
 ```
 
 or from source
 
 ```sh
 cd charts/cbcontainers-operator
-helm install cbcontainers-operator ./cbcontainers-operator-chart
+helm install cbcontainers-operator ./cbcontainers-operator-chart --namespace X
 ```
 
 ## Customization
 
-| Parameter                                              | Description                                                      | Default                                                                            |
-| ------------------------------------------------------ | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `spec.operator.image.repository`                       | The repository of the operator image                             | `cbartifactory/octarine-operator`                                                  |
-| `spec.operator.image.version`                          | The version of the operator image                                | The latest version of the operator image                                                                            |
-| `spec.operator.resources`                              | Carbon Black Container Operator resources                        | `{requests: {memory: "64Mi", cpu: "30m"}, limits: {memory: "256Mi", cpu: "200m"}}` |
-| `spec.rbacProxy.resources`                             | Kube RBAC Proxy resources                                        | `{requests: {memory: "64Mi", cpu: "30m"}, limits: {memory: "256Mi", cpu: "200m"}}` |
-| `spec.operator.environment`                            | Environment variables to be set to the operator pod              | []                                                                                 |
+| Parameter                        | Description                                         | Default                                                                            |
+|----------------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------|
+| `spec.operator.image.repository` | The repository of the operator image                | `cbartifactory/octarine-operator`                                                  |
+| `spec.operator.image.version`    | The version of the operator image                   | The latest version of the operator image                                           |
+| `spec.operator.resources`        | Carbon Black Container Operator resources           | `{requests: {memory: "64Mi", cpu: "30m"}, limits: {memory: "256Mi", cpu: "200m"}}` |
+| `spec.rbacProxy.resources`       | Kube RBAC Proxy resources                           | `{requests: {memory: "64Mi", cpu: "30m"}, limits: {memory: "256Mi", cpu: "200m"}}` |
+| `spec.operator.environment`      | Environment variables to be set to the operator pod | []                                                                                 |
 
 ### HTTP Proxy
 
@@ -45,13 +70,13 @@ For more info see <https://github.com/octarinesec/octarine-operator/tree/master#
 
 ## Templates
 
-This chart consists of two [templates](cbcontainers-operator-chart/templates/).
+This chart consists of two [templates](cbcontainers-operator-chart/templates).
 
-The [operator.yaml](operator.yaml) file contains all resource, apart from the operator deployment.
+The [operator.yaml](cbcontainers-operator-chart/templates/operator.yaml) file contains all resource, apart from the operator deployment.
 It is generated with via `kustomize`.
-For more info see [config/default_chart](../../../../config/default_chart/).
+For more info see [config/default_chart](../../config/default_chart).
 
-The [deployment.yaml](deployment.yaml) file contains the operator Deployment resource.
-It is derived from [this Kustomize configuration](../../../../config/manager) but because it needs to be configurable via Helm it is heavily templated.
+The [deployment.yaml](cbcontainers-operator-chart/templates/deployment.yaml) file contains the operator Deployment resource.
+It is derived from [this Kustomize configuration](../../config/manager) but because it needs to be configurable via Helm it is heavily templated.
 Because of that it cannot be generated automatically, so it should be maintained by hand.
-If any changes are make to the [Kustomize configuration](../../../../config/manager), they should also be reflected in that file.
+If any changes are make to the [Kustomize configuration](../../config/manager), they should also be reflected in that file.


### PR DESCRIPTION
Changes:
* Adds missing service accounts and RBAC to the dataplane services
* Adds a clarification on how to pick a namespace for the helm release. Previously our docs were installing in whatever namespace was current for the user, which is not ideal and can lead to confusion sometimes.

On point 2, I added 2 options - using an explicit interface of the user's choosing or creating our own dataplane namespace manually and letting helm "adopt" it. The latter is recommended so the whole deployment is self-sufficient in the `cbcontainers-dataplane` namespace but I still added both since they are valid.


Note: The `TODO` for helm repositories will be fixed separately. 