### PR TITLE
Remove default version from chart to avoid installing old versions by chance

### DIFF
--- a/charts/cbcontainers-agent/cbcontainers-agent-chart/values.yaml
+++ b/charts/cbcontainers-agent/cbcontainers-agent-chart/values.yaml
@@ -3,7 +3,7 @@ accessToken: ""
 # orgKey is the ID of the organization account
 orgKey: ""
 # version is the version of the agent that will be installed
-version: "2.4.0"
+version: ""
 # clusterGroup is the group that the cluster will belong to.
 clusterGroup: ""
 # clusterName is the name that will be used for the cluster that the agent is installed on


### PR DESCRIPTION
The other option is to update it on every release but I think this should be a conscious decision by the user. 