### PR TITLE
Merge back 5.6.2 into main

### DIFF
--- a/cbcontainers/state/components/enforcer_mutating_webhook.go
+++ b/cbcontainers/state/components/enforcer_mutating_webhook.go
@@ -206,6 +206,8 @@ func (obj *EnforcerMutatingWebhookK8sObject) getResourcesList() []string {
 		"cronjobs",
 		"ingresses",
 		"customresourcedefinitions",
+		"deploymentconfigs",
+		"routes",
 	}
 }
 

--- a/cbcontainers/state/components/enforcer_validating_webhook.go
+++ b/cbcontainers/state/components/enforcer_validating_webhook.go
@@ -216,6 +216,8 @@ func (obj *EnforcerValidatingWebhookK8sObject) getResourcesList() []string {
 		"cronjobs",
 		"ingresses",
 		"customresourcedefinitions",
+		"deploymentconfigs",
+		"routes",
 	}
 }
 

--- a/charts/cbcontainers-agent/cbcontainers-agent-chart/templates/rbac.yaml
+++ b/charts/cbcontainers-agent/cbcontainers-agent-chart/templates/rbac.yaml
@@ -81,6 +81,8 @@ rules:
       - networking.k8s.io
       - rbac
       - rbac.authorization.k8s.io
+      - apps.openshift.io
+      - route.openshift.io
     resources:
       - clusterrolebindings
       - cronjobs
@@ -97,6 +99,8 @@ rules:
       - rolebindings
       - services
       - statefulsets
+      - deploymentconfigs
+      - routes
     verbs:
       - watch
 ---

--- a/config/rbac/dataplane_roles.yaml
+++ b/config/rbac/dataplane_roles.yaml
@@ -95,6 +95,8 @@ rules:
       - networking.k8s.io
       - rbac
       - rbac.authorization.k8s.io
+      - apps.openshift.io
+      - route.openshift.io
     resources:
       - clusterrolebindings
       - cronjobs
@@ -111,5 +113,7 @@ rules:
       - rolebindings
       - services
       - statefulsets
+      - deploymentconfigs
+      - routes
     verbs:
       - watch


### PR DESCRIPTION
... with conflicts resolved. 
In practice, all CRI-O and runtime security changes were already on main so this only includes the state-reporter/enforcer changes. 

