### PR TITLE
Toggle features based on what the remotely configured sensor version supports

### DIFF
--- a/cbcontainers/remote_configuration/change_applier.go
+++ b/cbcontainers/remote_configuration/change_applier.go
@@ -6,27 +6,75 @@ import (
 )
 
 // ApplyConfigChangeToCR will modify CR according to the values in the configuration change provided
-func ApplyConfigChangeToCR(change models.ConfigurationChange, cr *cbcontainersv1.CBContainersAgent) {
+// If sensorMetadata is provided, specific supported features will be enabled or disabled based on their compatibility with the requested agent version
+func ApplyConfigChangeToCR(change models.ConfigurationChange, cr *cbcontainersv1.CBContainersAgent, sensorMetadata []models.SensorMetadata) {
 	if change.AgentVersion != nil {
 		cr.Spec.Version = *change.AgentVersion
 
-		// We do not set the tag to the version as that would make it harder to upgrade manually
-		// Instead, we reset any "custom" tags, which will fall back to the default (spec.Version)
-		images := []*cbcontainersv1.CBContainersImageSpec{
-			&cr.Spec.Components.Basic.Monitor.Image,
-			&cr.Spec.Components.Basic.Enforcer.Image,
-			&cr.Spec.Components.Basic.StateReporter.Image,
-			&cr.Spec.Components.ClusterScanning.ImageScanningReporter.Image,
-			&cr.Spec.Components.ClusterScanning.ClusterScannerAgent.Image,
-			&cr.Spec.Components.RuntimeProtection.Sensor.Image,
-			&cr.Spec.Components.RuntimeProtection.Resolver.Image,
-		}
-		if cr.Spec.Components.Cndr != nil {
-			images = append(images, &cr.Spec.Components.Cndr.Sensor.Image)
-		}
+		resetImageTagsInCR(cr)
+		toggleFeaturesBasedOnCompatibility(cr, *change.AgentVersion, sensorMetadata)
+	}
+}
 
-		for _, i := range images {
-			i.Tag = ""
+func resetImageTagsInCR(cr *cbcontainersv1.CBContainersAgent) {
+	// We do not set the tag to the version as that would make it harder to upgrade manually
+	// Instead, we reset any "custom" tags, which will fall back to the default (spec.Version)
+	images := []*cbcontainersv1.CBContainersImageSpec{
+		&cr.Spec.Components.Basic.Monitor.Image,
+		&cr.Spec.Components.Basic.Enforcer.Image,
+		&cr.Spec.Components.Basic.StateReporter.Image,
+		&cr.Spec.Components.ClusterScanning.ImageScanningReporter.Image,
+		&cr.Spec.Components.ClusterScanning.ClusterScannerAgent.Image,
+		&cr.Spec.Components.RuntimeProtection.Sensor.Image,
+		&cr.Spec.Components.RuntimeProtection.Resolver.Image,
+	}
+	if cr.Spec.Components.Cndr != nil {
+		images = append(images, &cr.Spec.Components.Cndr.Sensor.Image)
+	}
+
+	for _, i := range images {
+		i.Tag = ""
+	}
+}
+
+func toggleFeaturesBasedOnCompatibility(cr *cbcontainersv1.CBContainersAgent, version string, sensorMetadata []models.SensorMetadata) {
+	var sensorMetadataForVersion *models.SensorMetadata
+	for _, sensor := range sensorMetadata {
+		if sensor.Version == version {
+			sensorMetadataForVersion = &sensor
+			break
 		}
+	}
+	if sensorMetadataForVersion == nil {
+		return
+	}
+
+	trueRef, falseRef := true, false
+
+	if sensorMetadataForVersion.SupportsClusterScanning {
+		cr.Spec.Components.ClusterScanning.Enabled = &trueRef
+	} else {
+		cr.Spec.Components.ClusterScanning.Enabled = &falseRef
+	}
+
+	if sensorMetadataForVersion.SupportsClusterScanningSecrets {
+		cr.Spec.Components.ClusterScanning.ClusterScannerAgent.CLIFlags.EnableSecretDetection = true
+	} else {
+		cr.Spec.Components.ClusterScanning.ClusterScannerAgent.CLIFlags.EnableSecretDetection = false
+	}
+
+	if sensorMetadataForVersion.SupportsRuntime {
+		cr.Spec.Components.RuntimeProtection.Enabled = &trueRef
+	} else {
+		cr.Spec.Components.RuntimeProtection.Enabled = &falseRef
+	}
+
+	if cr.Spec.Components.Cndr == nil {
+		cr.Spec.Components.Cndr = &cbcontainersv1.CBContainersCndrSpec{}
+	}
+	if sensorMetadataForVersion.SupportsCndr {
+		cr.Spec.Components.Cndr.Enabled = &trueRef
+	} else {
+		cr.Spec.Components.Cndr.Enabled = &falseRef
 	}
 }

--- a/cbcontainers/remote_configuration/configurator.go
+++ b/cbcontainers/remote_configuration/configurator.go
@@ -176,7 +176,13 @@ func (configurator *Configurator) applyChangeToCR(ctx context.Context, apiGatewa
 	if err := validator.ValidateChange(change, cr); err != nil {
 		return invalidChangeError{msg: err.Error()}
 	}
-	ApplyConfigChangeToCR(change, cr)
+
+	sensorMeta, err := apiGateway.GetSensorMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to load sensor metadata from backend; %w", err)
+	}
+
+	ApplyConfigChangeToCR(change, cr, sensorMeta)
 	return configurator.k8sClient.Update(ctx, cr)
 }
 


### PR DESCRIPTION
As requested by product, the remote configurator should prioritize ease-of-use and automatically enable/disable features that the new sensor version supports (if it is provided). 